### PR TITLE
Fix leading zero handling in normalize_number

### DIFF
--- a/Whatsapp_Chat_Exporter/vcards_contacts.py
+++ b/Whatsapp_Chat_Exporter/vcards_contacts.py
@@ -82,5 +82,7 @@ def normalize_number(number: str, country_code: str) -> str:
 
     if number.startswith("0"):
         number = number[1:]
+        if not country_code:
+            return number
 
     return country_code + number

--- a/Whatsapp_Chat_Exporter/vcards_contacts_test.py
+++ b/Whatsapp_Chat_Exporter/vcards_contacts_test.py
@@ -29,3 +29,5 @@ def test_normalize_number():
     assert normalize_number('+1531234567', '34') == '1531234567'
     assert normalize_number('053(123)4567', '34') == '34531234567'
     assert normalize_number('0531-234-567', '58') == '58531234567'
+    assert normalize_number('0531234567', '') == '531234567'
+    assert normalize_number('0531-234-567', '') == '531234567'


### PR DESCRIPTION
## Summary
- strip leading zero when country code is empty
- test zero-stripping logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae2a490cc832fb6768402c2946ff8