### PR TITLE
Complete BPList writer

### DIFF
--- a/Whatsapp_Chat_Exporter/bplist.py
+++ b/Whatsapp_Chat_Exporter/bplist.py
@@ -23,37 +23,32 @@
 import struct
 import codecs
 from datetime import datetime, timedelta
+from plistlib import dumps, FMT_BINARY
 
 class BPListWriter(object):
     def __init__(self, objects):
-        self.bplist = ""
+        self.bplist = b""
         self.objects = objects
     
     def binary(self):
         '''binary -> string
-        
+
         Generates bplist
         '''
-        self.data = 'bplist00'
-        
-        # TODO: flatten objects and count max length size
-        
-        # TODO: write objects and save offsets
-        
-        # TODO: write offsets
-        
-        # TODO: write metadata
-        
-        return self.data
+        # The reader expects bytes starting with the bplist magic header.
+        # Use the builtin plistlib implementation to ensure compliance with the
+        # binary plist specification.
+        self.bplist = dumps(self.objects, fmt=FMT_BINARY)
+        return self.bplist
     
     def write(self, filename):
         '''
         
         Writes bplist to file
         '''
-        if self.bplist != "":
-            pass
-            # TODO: save self.bplist to file
+        if self.bplist != b"":
+            with open(filename, "wb") as fp:
+                fp.write(self.bplist)
         else:
             raise Exception('BPlist not yet generated')
 

--- a/Whatsapp_Chat_Exporter/bplist_test.py
+++ b/Whatsapp_Chat_Exporter/bplist_test.py
@@ -1,0 +1,22 @@
+from Whatsapp_Chat_Exporter.bplist import BPListWriter, BPListReader
+
+
+def test_binary_roundtrip():
+    obj = {"a": 1, "b": [1, 2, 3], "c": {"d": True}}
+    writer = BPListWriter(obj)
+    data = writer.binary()
+    assert data.startswith(b"bplist00")
+    parsed = BPListReader(data).parse()
+    assert parsed == obj
+
+
+def test_write(tmp_path):
+    obj = {"x": "y"}
+    writer = BPListWriter(obj)
+    writer.binary()
+    path = tmp_path / "test.plist"
+    writer.write(path)
+    with open(path, "rb") as f:
+        read_data = f.read()
+    assert read_data == writer.bplist
+    assert BPListReader(read_data).parse() == {"x": b"y"}


### PR DESCRIPTION
## Summary
- implement `BPListWriter.binary` using `plistlib` to generate valid binary plists
- implement `BPListWriter.write`
- add tests ensuring writer output is parsable by `BPListReader`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b1fb2b360832f85a5fe45154abf1b