### PR TITLE
Handle android avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd working_wts
 ### Unencrypted WhatsApp database
 Extract the WhatsApp database with whatever means, one possible means is to use the [WhatsApp-Key-DB-Extractor](https://github.com/KnugiHK/WhatsApp-Key-DB-Extractor). Note that the extractor only works on Android 4.0 to 13.
 
-After you obtain your WhatsApp database, copy the WhatsApp database and media folder to the working directory. The database is called msgstore.db. If you also want the name of your contacts, get the contact database, which is called wa.db. And copy the WhatsApp (Media) directory from your phone directly.
+After you obtain your WhatsApp database, copy the WhatsApp database and media folder to the working directory. The database is called msgstore.db. If you also want the name of your contacts, get the contact database, which is called wa.db. And copy the WhatsApp (Media) directory from your phone directly. Your own profile picture can typically be found at `WhatsApp/Media/WhatsApp Profile Photos/me.jpg`.
 
 And now, you should have something like this in the working directory.
 

--- a/Whatsapp_Chat_Exporter/data_model.py
+++ b/Whatsapp_Chat_Exporter/data_model.py
@@ -158,7 +158,8 @@ class ChatStore:
         Args:
             type (str): Device type (IOS or ANDROID)
             name (Optional[str]): Chat name
-            media (Optional[str]): Path to media folder
+            media (Optional[str]): Path to WhatsApp folder containing the Media
+                directory
         
         Raises:
             TypeError: If name is not a string or None
@@ -171,9 +172,12 @@ class ChatStore:
         if media is not None:
             from Whatsapp_Chat_Exporter.utility import Device
             if self.type == Device.IOS:
-                self.my_avatar = os.path.join(media, "Media/Profile/Photo.jpg")
+                self.my_avatar = os.path.join(media, "Media", "Profile",
+                                             "Photo.jpg")
             elif self.type == Device.ANDROID:
-                self.my_avatar = None  # TODO: Add Android support
+                self.my_avatar = os.path.join(
+                    media, "Media", "WhatsApp Profile Photos", "me.jpg"
+                )
             else:
                 self.my_avatar = None
         else:


### PR DESCRIPTION
## Summary
- locate Android profile photos
- set `my_avatar` when exporting from Android
- document new path for Android profile photo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4c007374832fa232c8ca7ba9e191