### PR TITLE
Add chat normalization utilities

### DIFF
--- a/Whatsapp_Chat_Exporter/__init__.py
+++ b/Whatsapp_Chat_Exporter/__init__.py
@@ -1,0 +1,5 @@
+"""WhatsApp Chat Exporter package."""
+
+from .normalizer import NormalizedMessage, normalize_collection
+
+__all__ = ["NormalizedMessage", "normalize_collection"]

--- a/Whatsapp_Chat_Exporter/normalizer.py
+++ b/Whatsapp_Chat_Exporter/normalizer.py
@@ -1,0 +1,75 @@
+"""Data normalization utilities for WhatsApp chats."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from typing import Iterator, Optional
+
+from pydantic import BaseModel
+
+from Whatsapp_Chat_Exporter.data_model import ChatCollection, Message
+
+
+class NormalizedMessage(BaseModel):
+    """Normalized representation of a WhatsApp message."""
+
+    chat_id: str
+    sender: Optional[str]
+    timestamp: datetime
+    message_type: str
+    content: Optional[str] = None
+    media_path: Optional[str] = None
+    mime_type: Optional[str] = None
+    delivered: Optional[datetime] = None
+    read: Optional[datetime] = None
+    from_me: bool
+
+
+def _to_datetime(ts: Optional[int | str], tz_offset: int) -> Optional[datetime]:
+    if ts is None:
+        return None
+    tz = timezone(timedelta(hours=tz_offset))
+    if isinstance(ts, str):
+        try:
+            return datetime.strptime(ts, "%Y/%m/%d %H:%M").replace(tzinfo=tz)
+        except ValueError:
+            return None
+    seconds = ts if ts < 1_000_000_000_0 else ts / 1000
+    return datetime.fromtimestamp(seconds, tz)
+
+
+def _message_type(msg: Message) -> str:
+    if msg.meta:
+        return "meta"
+    if msg.media:
+        return "media"
+    return "text"
+
+
+def normalize_collection(
+    collection: ChatCollection, tz_offset: int = 0
+) -> Iterator[NormalizedMessage]:
+    """Yield normalized messages from a :class:`ChatCollection`.
+
+    Args:
+        collection: Parsed chat collection.
+        tz_offset: Hours offset from UTC for timestamps.
+
+    Yields:
+        :class:`NormalizedMessage` objects.
+    """
+
+    for chat_id, chat in collection.items():
+        for message in chat.values():
+            yield NormalizedMessage(
+                chat_id=chat_id,
+                sender=message.sender if not message.from_me else None,
+                timestamp=_to_datetime(message.timestamp, tz_offset),
+                message_type=_message_type(message),
+                content=message.data,
+                media_path=message.data if message.media else None,
+                mime_type=message.mime,
+                delivered=_to_datetime(message.received_timestamp, tz_offset),
+                read=_to_datetime(message.read_timestamp, tz_offset),
+                from_me=message.from_me,
+            )

--- a/Whatsapp_Chat_Exporter/test_normalizer.py
+++ b/Whatsapp_Chat_Exporter/test_normalizer.py
@@ -1,0 +1,28 @@
+from Whatsapp_Chat_Exporter.data_model import ChatCollection, ChatStore, Message
+from Whatsapp_Chat_Exporter.utility import Device
+from Whatsapp_Chat_Exporter.normalizer import normalize_collection
+
+
+def test_normalize_collection():
+    collection = ChatCollection()
+    chat = ChatStore(Device.ANDROID, name="Alice")
+    msg = Message(
+        from_me=1,
+        timestamp=1_660_000_000,
+        time=1_660_000_000,
+        key_id=1,
+        received_timestamp=1_660_000_001,
+        read_timestamp=1_660_000_002,
+        timezone_offset=0,
+    )
+    msg.data = "hello"
+    chat.add_message("1", msg)
+    collection.add_chat("123@c.us", chat)
+
+    normalized = list(normalize_collection(collection))
+    assert len(normalized) == 1
+    n = normalized[0]
+    assert n.chat_id == "123@c.us"
+    assert n.content == "hello"
+    assert n.from_me is True
+    assert n.timestamp.tzinfo is not None


### PR DESCRIPTION
## Summary
- expose new `normalize_collection` API to transform `ChatCollection` into unified data
- include Pydantic-based `NormalizedMessage` model
- test normalization output

## Testing
- `ruff check Whatsapp_Chat_Exporter/normalizer.py Whatsapp_Chat_Exporter/test_normalizer.py`
- `black Whatsapp_Chat_Exporter/normalizer.py Whatsapp_Chat_Exporter/test_normalizer.py --line-length 99`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b503f6910832f87e6e99ecdf87ffc