### PR TITLE
Add streaming JSON export option

### DIFF
--- a/Whatsapp_Chat_Exporter/test_stream_json.py
+++ b/Whatsapp_Chat_Exporter/test_stream_json.py
@@ -1,0 +1,19 @@
+import json
+from types import SimpleNamespace
+from Whatsapp_Chat_Exporter.__main__ import export_single_json, export_single_json_stream
+
+
+def create_sample_dict():
+    return {"chat": {"name": "Test", "messages": {"1": {"data": "hi"}}}}
+
+
+def test_streaming_json(tmp_path):
+    data = create_sample_dict()
+    std = tmp_path / "std.json"
+    stream = tmp_path / "stream.json"
+    args = SimpleNamespace(json=str(std), avoid_encoding_json=False, pretty_print_json=None)
+    export_single_json(args, data)
+    args.json = str(stream)
+    export_single_json_stream(args, data)
+    with open(std) as f1, open(stream) as f2:
+        assert json.load(f1) == json.load(f2)


### PR DESCRIPTION
## Summary
- add `--stream-json` CLI flag to stream JSON output
- implement `export_single_json_stream` helper
- test streaming JSON export matches normal export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b506666e4832f85b0146c7d568aef