### PR TITLE
Optimize message parsing

### DIFF
--- a/Whatsapp_Chat_Exporter/android_handler.py
+++ b/Whatsapp_Chat_Exporter/android_handler.py
@@ -645,8 +645,13 @@ def _process_single_media(data, content, media_folder, mime, separate_media):
         
         # Copy media to separate folder if needed
         if separate_media:
-            chat_display_name = slugify(current_chat.name or message.sender 
-                                     or content["key_remote_jid"].split('@')[0], True)
+            if not current_chat.slug:
+                current_chat.slug = slugify(
+                    current_chat.name or message.sender
+                    or content["key_remote_jid"].split('@')[0],
+                    True,
+                )
+            chat_display_name = current_chat.slug
             current_filename = file_path.split("/")[-1]
             new_folder = os.path.join(media_folder, "separated", chat_display_name)
             Path(new_folder).mkdir(parents=True, exist_ok=True)
@@ -1067,7 +1072,7 @@ def create_txt(data, output):
 
 def _format_message_for_txt(message, contact):
     """Format a message for text output."""
-    date = datetime.fromtimestamp(message.timestamp).date()
+    date = message.date
     
     # Determine the sender name
     if message.from_me:

--- a/Whatsapp_Chat_Exporter/data_model.py
+++ b/Whatsapp_Chat_Exporter/data_model.py
@@ -167,6 +167,11 @@ class ChatStore:
         if name is not None and not isinstance(name, str):
             raise TypeError("Name must be a string or None")
         self.name = name
+        if name:
+            from Whatsapp_Chat_Exporter.utility import slugify
+            self.slug = slugify(name, True)
+        else:
+            self.slug = None
         self._messages: Dict[str, 'Message'] = {}
         self.type = type
         if media is not None:
@@ -277,6 +282,7 @@ class Message:
             self.time = time
         else:
             raise TypeError("Time must be a string or number")
+        self.date = timing.format_timestamp(self.timestamp, "%Y-%m-%d")
 
         self.media = False
         self.key_id = key_id
@@ -302,6 +308,7 @@ class Message:
             'from_me': self.from_me,
             'timestamp': self.timestamp,
             'time': self.time,
+            'date': self.date,
             'media': self.media,
             'key_id': self.key_id,
             'meta': self.meta,

--- a/Whatsapp_Chat_Exporter/ios_handler.py
+++ b/Whatsapp_Chat_Exporter/ios_handler.py
@@ -118,6 +118,7 @@ def messages(db, data, media_folder, timezone_offset, filter_date, filter_chat, 
         else:
             current_chat = data.get_chat(contact_id)
             current_chat.name = contact_name
+            current_chat.slug = slugify(contact_name, True)
             current_chat.my_avatar = os.path.join(media_folder, "Media/Profile/Photo.jpg")
         
         # Process avatar images
@@ -393,7 +394,12 @@ def process_media_item(content, data, media_folder, mime, separate_media):
         
         # Handle separate media option
         if separate_media:
-            chat_display_name = slugify(current_chat.name or message.sender or content["ZCONTACTJID"].split('@')[0], True)
+            if not current_chat.slug:
+                current_chat.slug = slugify(
+                    current_chat.name or message.sender or content["ZCONTACTJID"].split('@')[0],
+                    True,
+                )
+            chat_display_name = current_chat.slug
             current_filename = file_path.split("/")[-1]
             new_folder = os.path.join(media_folder, "separated", chat_display_name)
             Path(new_folder).mkdir(parents=True, exist_ok=True)

--- a/Whatsapp_Chat_Exporter/test_message.py
+++ b/Whatsapp_Chat_Exporter/test_message.py
@@ -1,0 +1,74 @@
+import datetime
+from Whatsapp_Chat_Exporter.data_model import Message
+
+
+def test_message_date_attribute():
+    ts = 1_660_000_000
+    msg = Message(
+        from_me=1,
+        timestamp=ts,
+        time=ts,
+        key_id=1,
+        received_timestamp=ts + 1,
+        read_timestamp=ts + 2,
+        timezone_offset=0,
+    )
+    expected = datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+    assert msg.date == expected
+
+from types import SimpleNamespace
+from pathlib import Path
+from mimetypes import MimeTypes
+import builtins
+import os
+
+from Whatsapp_Chat_Exporter.data_model import ChatCollection, ChatStore
+from Whatsapp_Chat_Exporter.utility import Device
+import Whatsapp_Chat_Exporter.android_handler as android_handler
+
+
+def test_slug_cached(monkeypatch, tmp_path):
+    data = ChatCollection()
+    chat = ChatStore(Device.ANDROID)
+    ts = 1_660_000_000
+    msg = Message(
+        from_me=1,
+        timestamp=ts,
+        time=ts,
+        key_id=1,
+        received_timestamp=ts + 1,
+        read_timestamp=ts + 2,
+        timezone_offset=0,
+    )
+    chat.add_message("1", msg)
+    data.add_chat("123@c.us", chat)
+
+    media_dir = tmp_path
+    (media_dir / "thumbnails").mkdir()
+    file_path = media_dir / "img.jpg"
+    file_path.write_bytes(b"a")
+
+    content = {
+        "file_path": "img.jpg",
+        "message_row_id": "1",
+        "key_remote_jid": "123@c.us",
+        "mime_type": None,
+        "file_hash": b"hash",
+        "thumbnail": None,
+    }
+
+    calls = []
+
+    def fake_slugify(value, allow_unicode):
+        calls.append(value)
+        return "slugged"
+
+    monkeypatch.setattr(android_handler, "slugify", fake_slugify)
+
+    mime = MimeTypes()
+    android_handler._process_single_media(data, content, str(media_dir), mime, True)
+    android_handler._process_single_media(data, content, str(media_dir), mime, True)
+
+    assert chat.slug == "slugged"
+    assert len(calls) == 1
+


### PR DESCRIPTION
## Summary
- cache slugified names to avoid repeated calls
- precompute message dates
- use cached date in text export
- update iOS contact processing to maintain slug
- add regression tests for caching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ba6bd6780832fbaec0811cf2ebcec