### PR TITLE
Fix missing psutil import

### DIFF
--- a/Whatsapp_Chat_Exporter/__main__.py
+++ b/Whatsapp_Chat_Exporter/__main__.py
@@ -10,6 +10,7 @@ import glob
 import importlib.metadata
 import zipfile
 import tarfile
+import psutil
 from Whatsapp_Chat_Exporter import android_crypt, exported_handler, android_handler
 from Whatsapp_Chat_Exporter import ios_handler, ios_media_handler
 from Whatsapp_Chat_Exporter.data_model import ChatCollection, ChatStore


### PR DESCRIPTION
## Summary
- add missing `psutil` import in `__main__.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bleach')*

------
https://chatgpt.com/codex/tasks/task_e_686bcb06bdb0832fbe47bca8bb61e09c