### PR TITLE
Fix cleanup of media directories

### DIFF
--- a/Whatsapp_Chat_Exporter/__main__.py
+++ b/Whatsapp_Chat_Exporter/__main__.py
@@ -771,8 +771,13 @@ def process_calls(args, db, data: ChatCollection, filter_chat) -> None:
             ios_handler.calls(cdb, data, args.timezone_offset, filter_chat)
 
 
-def handle_media_directory(args) -> None:
-    """Handle media directory copying or moving."""
+def handle_media_directory(args, temp_dirs) -> None:
+    """Handle media directory copying or moving.
+
+    Args:
+        args: Parsed CLI arguments.
+        temp_dirs: List of temporary directories created during execution.
+    """
     if args.skip_media:
         print("\nSkipping media directory as per --skip-media", end="\n")
         return
@@ -780,7 +785,9 @@ def handle_media_directory(args) -> None:
         media_path = os.path.join(args.output, args.media)
 
         if os.path.isdir(media_path):
-            logger.info("WhatsApp directory already exists in output directory. Skipping...")
+            logger.info(
+                "WhatsApp directory already exists in output directory. Skipping..."
+            )
 
         else:
             if args.move_media:
@@ -794,8 +801,13 @@ def handle_media_directory(args) -> None:
             else:
                 logger.info("Copying media directory...")
                 shutil.copytree(args.media, media_path)
+
         if args.cleanup_temp and not args.move_media:
-            shutil.rmtree(args.media, ignore_errors=True)
+            abs_media = os.path.abspath(args.media)
+            for tmp in map(os.path.abspath, temp_dirs):
+                if os.path.commonpath([abs_media, tmp]) == tmp:
+                    shutil.rmtree(args.media, ignore_errors=True)
+                    break
 
 
 def create_output_files(args, data: ChatCollection, contact_store=None) -> None:
@@ -1066,7 +1078,7 @@ def run(args, parser) -> None:
         create_output_files(args, data, contact_store)
 
         # Handle media directory
-        handle_media_directory(args)
+        handle_media_directory(args, temp_dirs)
         report_resource_usage("After media handling")
 
     print("Everything is done!")

--- a/Whatsapp_Chat_Exporter/test_resource_management.py
+++ b/Whatsapp_Chat_Exporter/test_resource_management.py
@@ -22,23 +22,52 @@ def test_handle_media_skip(monkeypatch, tmp_path):
     monkeypatch.setattr(shutil, "copytree", fake_copy)
     monkeypatch.setattr(shutil, "move", fake_move)
 
-    handle_media_directory(args)
+    handle_media_directory(args, [])
     assert not called["copy"]
     assert not called["move"]
 
 
-def test_handle_media_cleanup(monkeypatch, tmp_path):
-    media = tmp_path / "media"
+def test_handle_media_cleanup_inside_temp(monkeypatch, tmp_path):
+    media_root = tmp_path / "temp"
+    media_root.mkdir()
+    media = media_root / "media"
     out = tmp_path / "out"
     media.mkdir()
     out.mkdir()
-    args = SimpleNamespace(media=str(media), output=str(out), move_media=False,
-                           skip_media=False, cleanup_temp=True)
+    args = SimpleNamespace(
+        media=str(media),
+        output=str(out),
+        move_media=False,
+        skip_media=False,
+        cleanup_temp=True,
+    )
 
     def fake_copy(src, dst):
         os.makedirs(dst, exist_ok=True)
 
     monkeypatch.setattr(shutil, "copytree", fake_copy)
 
-    handle_media_directory(args)
+    handle_media_directory(args, [str(media_root)])
     assert not media.exists()
+
+
+def test_handle_media_cleanup_outside_temp(monkeypatch, tmp_path):
+    media = tmp_path / "media"
+    out = tmp_path / "out"
+    media.mkdir()
+    out.mkdir()
+    args = SimpleNamespace(
+        media=str(media),
+        output=str(out),
+        move_media=False,
+        skip_media=False,
+        cleanup_temp=True,
+    )
+
+    def fake_copy(src, dst):
+        os.makedirs(dst, exist_ok=True)
+
+    monkeypatch.setattr(shutil, "copytree", fake_copy)
+
+    handle_media_directory(args, [])
+    assert media.exists()


### PR DESCRIPTION
## Summary
- track temporary directories
- safely clean up media when within those temp paths
- update resource management tests for safer cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686be1275d0c832f93018565704032ce