### PR TITLE
Fix add_chat return type

### DIFF
--- a/Whatsapp_Chat_Exporter/data_model.py
+++ b/Whatsapp_Chat_Exporter/data_model.py
@@ -99,16 +99,18 @@ class ChatCollection(MutableMapping):
         """
         return self._chats.get(chat_id)
 
-    def add_chat(self, chat_id: str, chat: 'ChatStore') -> None:
-        """
-        Add a new chat to the collection.
+    def add_chat(self, chat_id: str, chat: 'ChatStore') -> 'ChatStore':
+        """Add a new chat to the collection.
 
         Args:
-            chat_id (str): The ID for the chat
-            chat (ChatStore): The chat to add
+            chat_id (str): The ID for the chat.
+            chat (ChatStore): The chat to add.
+
+        Returns:
+            ChatStore: The stored chat instance.
 
         Raises:
-            TypeError: If chat is not a ChatStore object
+            TypeError: If ``chat`` is not a :class:`ChatStore` object.
         """
         if not isinstance(chat, ChatStore):
             raise TypeError("Chat must be a ChatStore object")


### PR DESCRIPTION
## Summary
- make `ChatCollection.add_chat` return the stored chat

## Testing
- `mypy Whatsapp_Chat_Exporter` *(fails: Found 47 errors in 8 files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be7c3a8e0832fa7caf7e74c1d5d16