### PR TITLE
Fix path traversal in iOS media extraction

### DIFF
--- a/Whatsapp_Chat_Exporter/ios_media_handler.py
+++ b/Whatsapp_Chat_Exporter/ios_media_handler.py
@@ -213,7 +213,16 @@ class BackupExtractor:
                     row = c.fetchone()
                     continue
 
-                destination = os.path.join(_wts_id, row["relativePath"])
+                rel_path = os.path.normpath(row["relativePath"])
+                if os.path.isabs(rel_path) or rel_path.startswith(".."):
+                    row = c.fetchone()
+                    continue
+
+                destination = os.path.join(_wts_id, rel_path)
+                dest_abs = os.path.abspath(_wts_id) + os.sep
+                if not os.path.abspath(destination).startswith(dest_abs):
+                    row = c.fetchone()
+                    continue
                 hashes = row["fileID"]
                 folder = hashes[:2]
                 flags = row["flags"]

--- a/Whatsapp_Chat_Exporter/test_ios_media_handler.py
+++ b/Whatsapp_Chat_Exporter/test_ios_media_handler.py
@@ -1,0 +1,54 @@
+import os
+import sqlite3
+from plistlib import dumps, FMT_BINARY
+from Whatsapp_Chat_Exporter import ios_media_handler
+from Whatsapp_Chat_Exporter.utility import WhatsAppIdentifier
+
+
+def _make_manifest(path: str, rows: list[tuple[str, str, int]]) -> None:
+    metadata = dumps({"$objects": [None, {"Birth": 0, "LastModified": 0}]}, fmt=FMT_BINARY)
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "CREATE TABLE Files (fileID TEXT, domain TEXT, relativePath TEXT, flags INTEGER, file BLOB)"
+        )
+        for file_id, rel_path, flags in rows:
+            conn.execute(
+                "INSERT INTO Files VALUES (?, ?, ?, ?, ?)",
+                (file_id, WhatsAppIdentifier.DOMAIN, rel_path, flags, metadata),
+            )
+        conn.commit()
+
+
+def test_extract_media_files_traversal(monkeypatch, tmp_path):
+    base_dir = tmp_path / "base"
+    base_dir.mkdir()
+    good_hash = "aa1111"
+    bad_hash = "bb2222"
+    abs_hash = "cc3333"
+    for h in (good_hash, bad_hash, abs_hash):
+        d = base_dir / h[:2]
+        d.mkdir(exist_ok=True)
+        (d / h).write_text(h)
+    _make_manifest(
+        base_dir / "Manifest.db",
+        [
+            ("dir000", "safe", 2),
+            (good_hash, "safe/good.txt", 1),
+            (bad_hash, "../evil.txt", 1),
+            (abs_hash, "/abs.txt", 1),
+        ],
+    )
+    work_dir = tmp_path / "wd"
+    work_dir.mkdir()
+    monkeypatch.chdir(work_dir)
+
+    extractor = ios_media_handler.BackupExtractor(
+        str(base_dir), WhatsAppIdentifier, decrypt_chunk_size=1024
+    )
+    extractor._extract_media_files()
+
+    out_root = work_dir / WhatsAppIdentifier.DOMAIN
+    assert (out_root / "safe" / "good.txt").is_file()
+    assert not (work_dir / "evil.txt").exists()
+    assert not (work_dir / "abs.txt").exists()
+


### PR DESCRIPTION
## Summary
- sanitize relative paths when extracting iOS media files
- add regression test for unsafe paths in the manifest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bf36f7944832fa89271d20d9d619e