### PR TITLE
Fix cross-platform media path handling

### DIFF
--- a/Whatsapp_Chat_Exporter/android_handler.py
+++ b/Whatsapp_Chat_Exporter/android_handler.py
@@ -847,7 +847,7 @@ def _process_single_media(
                 )
             chat_display_name = current_chat.slug
 
-            current_filename = file_path.split("/")[-1]
+            current_filename = os.path.basename(file_path)
             new_folder = os.path.join(media_folder, "separated", chat_display_name)
             Path(new_folder).mkdir(parents=True, exist_ok=True)
             new_path = os.path.join(new_folder, current_filename)

--- a/Whatsapp_Chat_Exporter/ios_handler.py
+++ b/Whatsapp_Chat_Exporter/ios_handler.py
@@ -446,7 +446,7 @@ def process_media_item(
         return
 
     if os.path.isfile(file_path):
-        message.data = "/".join(file_path.split("/")[1:])
+        message.data = os.path.relpath(file_path, Path(file_path).anchor)
 
         # Set MIME type
         if content["ZVCARDSTRING"] is None:
@@ -465,12 +465,12 @@ def process_media_item(
                     True,
                 )
             chat_display_name = current_chat.slug
-            current_filename = file_path.split("/")[-1]
+            current_filename = os.path.basename(file_path)
             new_folder = os.path.join(media_folder, "separated", chat_display_name)
             Path(new_folder).mkdir(parents=True, exist_ok=True)
             new_path = os.path.join(new_folder, current_filename)
             shutil.copy2(file_path, new_path)
-            message.data = "/".join(new_path.split("\\")[1:])
+            message.data = os.path.relpath(new_path, Path(new_path).anchor)
     else:
         # Handle missing media
         message.data = "The media is missing"

--- a/Whatsapp_Chat_Exporter/test_path_handling.py
+++ b/Whatsapp_Chat_Exporter/test_path_handling.py
@@ -1,0 +1,45 @@
+import os
+from mimetypes import MimeTypes
+
+from Whatsapp_Chat_Exporter import ios_handler
+from Whatsapp_Chat_Exporter.data_model import ChatCollection, ChatStore, Message
+from Whatsapp_Chat_Exporter.utility import Device
+
+
+def _make_msg() -> Message:
+    return Message(
+        from_me=1,
+        timestamp=1,
+        time=1,
+        key_id=1,
+        received_timestamp=1,
+        read_timestamp=1,
+    )
+
+
+def test_ios_media_relative_path(tmp_path):
+    media_dir = tmp_path / "media"
+    message_dir = media_dir / "Message"
+    file_rel = os.path.join("sub", "img.jpg")
+    file_path = message_dir / file_rel
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("x")
+
+    data = ChatCollection()
+    chat = ChatStore(Device.IOS)
+    chat.add_message("1", _make_msg())
+    data.add_chat("123@c.us", chat)
+
+    content = {
+        "ZMEDIALOCALPATH": file_rel,
+        "ZCONTACTJID": "123@c.us",
+        "ZMESSAGE": "1",
+        "ZVCARDSTRING": None,
+        "ZTITLE": None,
+    }
+
+    mime = MimeTypes()
+    ios_handler.process_media_item(content, data, str(media_dir), mime, False)
+
+    expected = os.path.relpath(str(file_path), file_path.anchor)
+    assert chat.get_message("1").data == expected


### PR DESCRIPTION
## Summary
- use `os.path.relpath` and `os.path.basename` when building media paths
- test that iOS media paths are stored relative to the filesystem root

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c4c74c120832fbda1dfcc6a42556e