### PR TITLE
Separate group vs individual chats

### DIFF
--- a/Whatsapp_Chat_Exporter/data_model.py
+++ b/Whatsapp_Chat_Exporter/data_model.py
@@ -161,16 +161,20 @@ class ChatStore:
     """
 
     def __init__(
-        self, type: str, name: Optional[str] = None, media: Optional[str] = None
+        self,
+        type: str,
+        name: Optional[str] = None,
+        media: Optional[str] = None,
+        is_group: bool = False,
     ) -> None:
-        """
-        Initialize ChatStore object.
+        """Initialize ChatStore object.
 
         Args:
             type (str): Device type (IOS or ANDROID)
             name (Optional[str]): Chat name
             media (Optional[str]): Path to WhatsApp folder containing the Media
                 directory
+            is_group (bool): True if this chat is a group chat
 
         Raises:
             TypeError: If name is not a string or None
@@ -186,6 +190,7 @@ class ChatStore:
             self.slug = None
         self._messages: Dict[str, "Message"] = {}
         self.type = type
+        self.is_group = is_group
         if media is not None:
             from Whatsapp_Chat_Exporter.utility import Device
 
@@ -228,6 +233,7 @@ class ChatStore:
         return {
             "name": self.name,
             "type": self.type,
+            "is_group": self.is_group,
             "my_avatar": self.my_avatar,
             "their_avatar": self.their_avatar,
             "their_avatar_thumb": self.their_avatar_thumb,

--- a/Whatsapp_Chat_Exporter/test_group_separation.py
+++ b/Whatsapp_Chat_Exporter/test_group_separation.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+from Whatsapp_Chat_Exporter import android_handler
+from Whatsapp_Chat_Exporter.__main__ import export_multiple_json
+from Whatsapp_Chat_Exporter.data_model import ChatCollection, ChatStore, Message
+from Whatsapp_Chat_Exporter.utility import Device
+
+
+def _msg() -> Message:
+    return Message(
+        from_me=1,
+        timestamp=1,
+        time=1,
+        key_id=1,
+        received_timestamp=1,
+        read_timestamp=1,
+    )
+
+
+def test_group_and_individual_dirs(tmp_path):
+    data = ChatCollection()
+    chat_ind = ChatStore(Device.ANDROID, name="Alice", is_group=False)
+    chat_ind.add_message("1", _msg())
+    data.add_chat("111@c.us", chat_ind)
+
+    chat_grp = ChatStore(Device.ANDROID, name="Group", is_group=True)
+    chat_grp.add_message("1", _msg())
+    data.add_chat("111-222@g.us", chat_grp)
+
+    android_handler.create_html(data, str(tmp_path), headline="Chat history with ??")
+
+    assert (tmp_path / "individuals").is_dir()
+    assert (tmp_path / "groups").is_dir()
+    assert any(f.suffix == ".html" for f in (tmp_path / "individuals").iterdir())
+    assert any(f.suffix == ".html" for f in (tmp_path / "groups").iterdir())
+
+    args = SimpleNamespace(
+        json=str(tmp_path / "json"), avoid_encoding_json=False, pretty_print_json=None
+    )
+    export_multiple_json(args, {jid: chat.to_json() for jid, chat in data.items()})
+
+    assert (tmp_path / "json" / "individuals").is_dir()
+    assert (tmp_path / "json" / "groups").is_dir()

--- a/Whatsapp_Chat_Exporter/utility.py
+++ b/Whatsapp_Chat_Exporter/utility.py
@@ -343,6 +343,11 @@ def sanitize_filename(file_name: str) -> str:
     return "".join(x for x in file_name if x.isalnum() or x in "- ")
 
 
+def is_group_jid(jid: str) -> bool:
+    """Return True if the JID represents a group chat."""
+    return "-" in jid
+
+
 def get_file_name(contact: str, chat: ChatStore) -> Tuple[str, str]:
     """Generates a sanitized filename and contact name for a chat.
 


### PR DESCRIPTION
## Summary
- track if a `ChatStore` is for a group chat
- create `groups` and `individuals` folders for HTML exports
- export per-chat JSON into `groups`/`individuals`
- utility helper to detect group JIDs
- test exporting groups vs individuals

## Testing
- `ruff check Whatsapp_Chat_Exporter/test_group_separation.py Whatsapp_Chat_Exporter/data_model.py Whatsapp_Chat_Exporter/android_handler.py Whatsapp_Chat_Exporter/ios_handler.py Whatsapp_Chat_Exporter/utility.py Whatsapp_Chat_Exporter/__main__.py`
- `mypy Whatsapp_Chat_Exporter/test_group_separation.py Whatsapp_Chat_Exporter/data_model.py Whatsapp_Chat_Exporter/android_handler.py Whatsapp_Chat_Exporter/ios_handler.py Whatsapp_Chat_Exporter/utility.py Whatsapp_Chat_Exporter/__main__.py` *(fails: Library stubs not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687199fa9688832fa5d084054792535e