### PR TITLE
Add chat cleaner utility

### DIFF
--- a/Whatsapp_Chat_Exporter/__init__.py
+++ b/Whatsapp_Chat_Exporter/__init__.py
@@ -1,5 +1,6 @@
 """WhatsApp Chat Exporter package."""
 
 from .normalizer import NormalizedMessage, normalize_collection
+from .chat_cleaner import ChatCleaner
 
-__all__ = ["NormalizedMessage", "normalize_collection"]
+__all__ = ["NormalizedMessage", "normalize_collection", "ChatCleaner"]

--- a/Whatsapp_Chat_Exporter/chat_cleaner.py
+++ b/Whatsapp_Chat_Exporter/chat_cleaner.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Set, Tuple
+
+from .data_model import ChatCollection
+
+
+class ChatCleaner:
+    """Utility for removing unwanted messages from chats."""
+
+    @staticmethod
+    def clean(
+        collection: ChatCollection,
+        remove_empty: bool = True,
+        deduplicate: bool = True,
+    ) -> None:
+        """Clean chats in place.
+
+        Args:
+            collection: Parsed chats.
+            remove_empty: Drop messages without text or media.
+            deduplicate: Drop duplicate messages based on timestamp and content.
+        """
+        for chat_id, chat in list(collection.items()):
+            seen: Set[Tuple[int, str | None, str | None, bool]] = set()
+            for msg_id in list(chat.keys()):
+                msg = chat.get_message(msg_id)
+                if msg is None:
+                    continue
+                unique = (msg.timestamp, msg.sender, msg.data, msg.from_me)
+                if deduplicate and unique in seen:
+                    chat.delete_message(msg_id)
+                    continue
+                seen.add(unique)
+                if remove_empty and not msg.data and not msg.media and not msg.meta:
+                    chat.delete_message(msg_id)
+            if remove_empty and len(chat) == 0:
+                collection.remove_chat(chat_id)

--- a/Whatsapp_Chat_Exporter/cli.py
+++ b/Whatsapp_Chat_Exporter/cli.py
@@ -21,5 +21,45 @@ def export(ctx: typer.Context) -> None:
     __main__.run(args, parser)
 
 
+@app.command()
+def clean(
+    input_json: str,
+    output_json: str,
+    remove_empty: bool = True,
+    deduplicate: bool = True,
+) -> None:
+    """Clean chats from a JSON export."""
+    from .chat_cleaner import ChatCleaner
+    from .data_model import ChatCollection, ChatStore, Message
+    import json
+
+    with open(input_json, "r") as f:
+        raw = json.load(f)
+
+    collection = ChatCollection()
+    for chat_id, chat_data in raw.items():
+        chat = ChatStore(chat_data.get("type", "android"), name=chat_data.get("name"))
+        for msg_id, msg_data in chat_data.get("messages", {}).items():
+            msg = Message(
+                from_me=msg_data.get("from_me", 0),
+                timestamp=msg_data.get("timestamp", 0),
+                time=msg_data.get("time", 0),
+                key_id=msg_data.get("key_id", 0),
+                received_timestamp=0,
+                read_timestamp=0,
+            )
+            msg.data = msg_data.get("data")
+            msg.media = msg_data.get("media", False)
+            msg.meta = msg_data.get("meta", False)
+            msg.sender = msg_data.get("sender")
+            chat.add_message(msg_id, msg)
+        collection.add_chat(chat_id, chat)
+
+    ChatCleaner.clean(collection, remove_empty, deduplicate)
+
+    with open(output_json, "w") as f:
+        json.dump(collection.to_dict(), f, ensure_ascii=False, indent=2)
+
+
 if __name__ == "__main__":
     app()

--- a/Whatsapp_Chat_Exporter/test_chat_cleaner.py
+++ b/Whatsapp_Chat_Exporter/test_chat_cleaner.py
@@ -1,0 +1,53 @@
+from Whatsapp_Chat_Exporter.chat_cleaner import ChatCleaner
+from Whatsapp_Chat_Exporter.data_model import ChatCollection, ChatStore, Message
+from Whatsapp_Chat_Exporter.utility import Device
+
+
+def _make_message(text: str | None, ts: int = 1) -> Message:
+    msg = Message(
+        from_me=1,
+        timestamp=ts,
+        time=ts,
+        key_id=ts,
+        received_timestamp=ts,
+        read_timestamp=ts,
+    )
+    msg.data = text
+    if text is None:
+        msg.media = False
+    return msg
+
+
+def test_clean_removes_empty_messages():
+    collection = ChatCollection()
+    chat = ChatStore(Device.ANDROID)
+    chat.add_message("1", _make_message(None))
+    chat.add_message("2", _make_message("hi"))
+    collection.add_chat("c", chat)
+
+    ChatCleaner.clean(collection)
+
+    assert list(chat.keys()) == ["2"]
+
+
+def test_clean_deduplicates():
+    collection = ChatCollection()
+    chat = ChatStore(Device.ANDROID)
+    chat.add_message("1", _make_message("hi", 1))
+    chat.add_message("2", _make_message("hi", 1))
+    collection.add_chat("c", chat)
+
+    ChatCleaner.clean(collection)
+
+    assert len(chat) == 1
+
+
+def test_clean_removes_empty_chats():
+    collection = ChatCollection()
+    chat = ChatStore(Device.ANDROID)
+    chat.add_message("1", _make_message(None))
+    collection.add_chat("c", chat)
+
+    ChatCleaner.clean(collection)
+
+    assert len(collection) == 0


### PR DESCRIPTION
## Summary
- implement `ChatCleaner` for deduplication and empty message removal
- expose new utility from package and integrate into Typer CLI
- add tests for cleaning behaviour

## Testing
- `ruff check --fix Whatsapp_Chat_Exporter/chat_cleaner.py Whatsapp_Chat_Exporter/cli.py Whatsapp_Chat_Exporter/test_chat_cleaner.py`
- `black Whatsapp_Chat_Exporter/chat_cleaner.py Whatsapp_Chat_Exporter/cli.py Whatsapp_Chat_Exporter/test_chat_cleaner.py`
- `mypy --ignore-missing-imports --follow-imports=skip Whatsapp_Chat_Exporter/chat_cleaner.py Whatsapp_Chat_Exporter/cli.py Whatsapp_Chat_Exporter/test_chat_cleaner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873203f3c20832f8ba4b684f9421be0