### PR TITLE
Fix media path lookup for exported chats

### DIFF
--- a/Whatsapp_Chat_Exporter/test_exported_handler.py
+++ b/Whatsapp_Chat_Exporter/test_exported_handler.py
@@ -49,3 +49,27 @@ def test_attached_file_traversal_rejected(tmp_path):
     msg = chat.get_message(0)
     assert msg.data == "The media is missing"
     assert msg.meta
+
+
+def test_attached_file_found_in_media_dir(tmp_path):
+    base = tmp_path / "chat"
+    base.mkdir()
+    media = base / "Media"
+    media.mkdir()
+    file_path = media / "photo.jpg"
+    file_path.write_text("data")
+
+    chat_file = base / "chat.txt"
+    chat_file.write_text("01/01/2024, 10:00 - Alice: photo.jpg (file attached)")
+
+    data = ChatCollection()
+    exported_handler.messages(
+        str(chat_file),
+        data,
+        assume_first_as_me=False,
+        prompt_user=False,
+    )
+
+    chat = data["ExportedChat"]
+    msg = chat.get_message(0)
+    assert msg.data == str(file_path)


### PR DESCRIPTION
## Summary
- search exported chat media subdirectories for attachments
- only scan when the chat line provides a filename without path
- test media lookup for exported chats

## Testing
- `ruff check Whatsapp_Chat_Exporter/exported_handler.py Whatsapp_Chat_Exporter/test_exported_handler.py`
- `mypy Whatsapp_Chat_Exporter/exported_handler.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68746e830230832f9be0a21bb054effe