### PR TITLE
Improve exported media copy concurrency

### DIFF
--- a/Whatsapp_Chat_Exporter/__main__.py
+++ b/Whatsapp_Chat_Exporter/__main__.py
@@ -33,6 +33,7 @@ from Whatsapp_Chat_Exporter.utility import (
     DbType,
     bytes_to_readable,
     check_update,
+    copy_parallel,
     extract_archive,
     import_from_json,
     readable_to_bytes,
@@ -520,6 +521,13 @@ def setup_argument_parser() -> ArgumentParser:
         help="Specify the maximum number of worker for bruteforce decryption.",
     )
     misc_group.add_argument(
+        "--copy-workers",
+        dest="copy_workers",
+        default=4,
+        type=int,
+        help="Number of worker threads for copying exported media files.",
+    )
+    misc_group.add_argument(
         "-v",
         "--verbose",
         dest="verbose",
@@ -618,6 +626,9 @@ def validate_args(parser: ArgumentParser, args) -> None:
     check_exists(args.wa, "Contact database")
     check_exists(args.wab, "Contact backup")
     check_exists(args.call_db_ios, "Call database")
+
+    if args.copy_workers < 1:
+        parser.error("--copy-workers must be at least 1")
 
     if (
         args.backup
@@ -882,11 +893,6 @@ def process_contacts(args, data: ChatCollection, contact_store=None) -> None:
     # Skip contact processing if using same database file as messages to avoid locks
     if os.path.isfile(contact_db) and contact_db != args.db:
         # Use original handlers to avoid database lock issues
-        filter_chat = (
-            getattr(args, "filter_chat_include", []),
-            getattr(args, "filter_chat_exclude", []),
-        )
-
         if args.android:
             import sqlite3
 
@@ -908,9 +914,7 @@ def process_messages(args, data: ChatCollection) -> None:
     msg_db = (
         args.db
         if args.db
-        else "msgstore.db"
-        if args.android
-        else args.identifiers.MESSAGE
+        else "msgstore.db" if args.android else args.identifiers.MESSAGE
     )
 
     if not os.path.isfile(msg_db):
@@ -1236,7 +1240,9 @@ def export_summary(args, data: ChatCollection) -> None:
         json.dump(summary, f, indent=2)
 
 
-def copy_exported_media(chat_file: str, data: ChatCollection, output_dir: str) -> None:
+def copy_exported_media(
+    chat_file: str, data: ChatCollection, output_dir: str, workers: int = 4
+) -> None:
     """Copy media referenced in an exported chat.
 
     Args:
@@ -1252,6 +1258,7 @@ def copy_exported_media(chat_file: str, data: ChatCollection, output_dir: str) -
     media_dir = os.path.join(output_dir, "media")
     os.makedirs(media_dir, exist_ok=True)
 
+    file_pairs: list[tuple[str, str]] = []
     for msg in chat.values():
         if msg.media and isinstance(msg.data, str) and os.path.isfile(msg.data):
             try:
@@ -1271,8 +1278,11 @@ def copy_exported_media(chat_file: str, data: ChatCollection, output_dir: str) -
                 continue
 
             os.makedirs(os.path.dirname(dst), exist_ok=True)
-            shutil.copy2(msg.data, dst)
+            file_pairs.append((msg.data, dst))
             msg.data = os.path.relpath(dst, output_dir)
+
+    if file_pairs:
+        copy_parallel(file_pairs, workers=workers)
 
     if chat.media_base == "":
         chat.media_base = "media/"
@@ -1287,7 +1297,12 @@ def process_exported_chat(args, data: ChatCollection) -> None:
         args.prompt_user,
     )
 
-    copy_exported_media(args.exported, data, args.output)
+    copy_exported_media(
+        args.exported,
+        data,
+        args.output,
+        workers=args.copy_workers,
+    )
 
     if not args.no_html:
         # Detect platform and use appropriate HTML generator

--- a/Whatsapp_Chat_Exporter/test_copy_exported_media.py
+++ b/Whatsapp_Chat_Exporter/test_copy_exported_media.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from Whatsapp_Chat_Exporter.__main__ import copy_exported_media
 from Whatsapp_Chat_Exporter.data_model import ChatCollection, ChatStore, Message
@@ -19,7 +20,7 @@ def _create_msg(path: str) -> Message:
     return msg
 
 
-def test_copy_exported_media_traversal(tmp_path):
+def test_copy_exported_media_traversal(tmp_path, monkeypatch):
     src = tmp_path / "src"
     src.mkdir()
     good = src / "good.txt"
@@ -45,11 +46,26 @@ def test_copy_exported_media_traversal(tmp_path):
     out_dir = tmp_path / "out"
     out_dir.mkdir()
 
-    copy_exported_media(str(chat_file), collection, str(out_dir))
+    captured = {}
+
+    def fake_copy_parallel(pairs, workers=4):
+        captured["pairs"] = pairs
+        captured["workers"] = workers
+        for s, d in pairs:
+            shutil.copy2(s, d)
+
+    monkeypatch.setattr(
+        "Whatsapp_Chat_Exporter.__main__.copy_parallel",
+        fake_copy_parallel,
+    )
+
+    copy_exported_media(str(chat_file), collection, str(out_dir), workers=2)
 
     copied = out_dir / "media" / "good.txt"
     assert copied.is_file()
     assert chat.get_message("1").data == os.path.relpath(copied, out_dir)
+    assert captured["pairs"] == [(str(good), str(copied))]
+    assert captured["workers"] == 2
 
     assert not (out_dir / "media" / "outside.txt").exists()
     assert not (out_dir / "media" / "abs.txt").exists()


### PR DESCRIPTION
## Summary
- add `--copy-workers` CLI option
- copy exported media using `copy_parallel`
- validate worker count in `validate_args`
- test concurrent media copy

## Testing
- `ruff check Whatsapp_Chat_Exporter/__main__.py Whatsapp_Chat_Exporter/test_copy_exported_media.py`
- `black Whatsapp_Chat_Exporter/__main__.py Whatsapp_Chat_Exporter/test_copy_exported_media.py`
- `pytest Whatsapp_Chat_Exporter/test_copy_exported_media.py -q`
- `pytest -q` *(fails: ChatCleaner.clean missing, path handling mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6875078d0fc0832fb4397755602884af